### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ rust-cpuid
 [![Build Status](https://travis-ci.org/zsiciarz/rust-cpuid.svg?branch=master)](https://travis-ci.org/zsiciarz/rust-cpuid)
 [![Coverage Status](https://coveralls.io/repos/zsiciarz/rust-cpuid/badge.svg?branch=master)](https://coveralls.io/r/zsiciarz/rust-cpuid?branch=master)
 
-Rust bindings for [libpcuid](https://github.com/anrieff/libcpuid)
+Rust bindings for [libcpuid](https://github.com/anrieff/libcpuid)
 CPU detection and feature extraction library.
 
 Usage


### PR DESCRIPTION
P.S.: The word "libcpuid" should also be fixed in the repo description (below the project name).
:wink: 