### PR TITLE
don't include NUL bytes at the end of the vendor, brand, and codename strings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,13 +234,22 @@ pub fn identify() -> Result<CpuInfo, String> {
         Err(error())
     } else {
         Ok(CpuInfo {
-            vendor: String::from_utf8(data.vendor_str.iter().map(|&x| x as u8).collect())
+            vendor: String::from_utf8(data.vendor_str.iter()
+                                        .take_while(|&&x| x != 0)
+                                        .map(|&x| x as u8)
+                                        .collect())
                         .ok()
                         .expect("Invalid vendor string"),
-            brand: String::from_utf8(data.brand_str.iter().map(|&x| x as u8).collect())
+            brand: String::from_utf8(data.brand_str.iter()
+                                        .take_while(|&&x| x != 0)
+                                        .map(|&x| x as u8)
+                                        .collect())
                        .ok()
                        .expect("Invalid brand string"),
-            codename: String::from_utf8(data.cpu_codename.iter().map(|&x| x as u8).collect())
+            codename: String::from_utf8(data.cpu_codename.iter()
+                                        .take_while(|&&x| x != 0)
+                                        .map(|&x| x as u8)
+                                        .collect())
                           .ok()
                           .expect("Invalid codename string"),
             num_cores: data.num_cores,


### PR DESCRIPTION
String::from_utf8 doesn't interpret its input as a null-terminated string, so since these are just static buffers of bytes, it ends up pulling in large numbers of zero-bytes at the end.